### PR TITLE
整理接口、泛型的应用

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSEnvironment } from "./lib/ECSEnvironment";
+import { IECSEnvironment } from "./lib/ECSEnvironment";
 import { ECSImpl } from "./lib/impl/ECSImpl";
 
 export * from "./lib/ECSComponent";
@@ -15,6 +15,6 @@ export { ecsclass } from "./lib/__private";
 /**
  * 创建 ECS 环境
  */
-export function createECSEnv(): ECSEnvironment {
+export function createECSEnv(): IECSEnvironment {
     return new ECSImpl();
 }

--- a/lib/ECSComponent.ts
+++ b/lib/ECSComponent.ts
@@ -5,7 +5,7 @@
 /**
  * 组件接口
  */
-export interface ECSComponentInterface {
+export interface IECSComponentInterface {
     /**
      * 组件的类名
      */
@@ -20,7 +20,7 @@ export interface ECSComponentInterface {
 /**
  * 组件
  */
-export abstract class ECSComponent implements ECSComponentInterface {
+export abstract class ECSComponent implements IECSComponentInterface {
     /**
      * 组件的类名
      */

--- a/lib/ECSComponents.ts
+++ b/lib/ECSComponents.ts
@@ -8,7 +8,7 @@ import { Constructor } from "./__private";
 /**
  * 组件集合
  */
-export interface ECSComponents {
+export interface IECSComponents {
     /**
      * 返回组件总数
      */

--- a/lib/ECSEntities.ts
+++ b/lib/ECSEntities.ts
@@ -7,7 +7,7 @@ import { ECSEntity } from "./ECSEntity";
 /**
  * 实体集合
  */
-export interface ECSEntities {
+export interface IECSEntities {
     /**
      * 返回实体总数
      */

--- a/lib/ECSEntity.ts
+++ b/lib/ECSEntity.ts
@@ -3,7 +3,7 @@
  */
 
 import { ECSComponentInterface } from "./ECSComponent";
-import { ECSComponents } from "./ECSComponents";
+import { IECSComponents } from "./ECSComponents";
 import { Constructor } from "./__private";
 
 /**
@@ -28,7 +28,7 @@ export class ECSEntity {
     /**
      * 全局组件集合，由 ECS 指定，让 Entity 可以直接将组件添加到 ECS 中
      */
-    __globalComponents: ECSComponents | undefined = undefined;
+    __globalComponents: IECSComponents | undefined = undefined;
 
     /**
      * 返回实体可用状态

--- a/lib/ECSEnvironment.ts
+++ b/lib/ECSEnvironment.ts
@@ -2,10 +2,10 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSComponents } from "./ECSComponents";
-import { ECSEntities } from "./ECSEntities";
+import { IECSComponents } from "./ECSComponents";
+import { IECSEntities } from "./ECSEntities";
 import { ECSEvents } from "./ECSEvents";
-import { ECSSystems } from "./ECSSystems";
+import { IECSSystems } from "./ECSSystems";
 
 /**
  * ECS 运行环境
@@ -29,7 +29,7 @@ import { ECSSystems } from "./ECSSystems";
  *   - 每个 system 执行时都可以查询事件队列
  * - 清理事件队列
  */
-export interface ECSEnvironment {
+export interface IECSEnvironment {
     /**
      * 事件集合
      */
@@ -38,17 +38,17 @@ export interface ECSEnvironment {
     /**
      * 系统集合
      */
-    readonly systems: ECSSystems;
+    readonly systems: IECSSystems;
 
     /**
      * 实体集合
      */
-    readonly entities: ECSEntities;
+    readonly entities: IECSEntities;
 
     /**
      * 组件集合
      */
-    readonly components: ECSComponents;
+    readonly components: IECSComponents;
 
     /**
      * 启动环境

--- a/lib/ECSEnvironment.ts
+++ b/lib/ECSEnvironment.ts
@@ -4,7 +4,7 @@
 
 import { IECSComponents } from "./ECSComponents";
 import { IECSEntities } from "./ECSEntities";
-import { ECSEvents } from "./ECSEvents";
+import { IECSEvents } from "./ECSEvents";
 import { IECSSystems } from "./ECSSystems";
 
 /**
@@ -33,7 +33,7 @@ export interface IECSEnvironment {
     /**
      * 事件集合
      */
-    readonly events: ECSEvents;
+    readonly events: IECSEvents;
 
     /**
      * 系统集合

--- a/lib/ECSEvents.ts
+++ b/lib/ECSEvents.ts
@@ -8,7 +8,7 @@ import { Constructor } from "./__private";
 /**
  * 事件队列
  */
-export interface ECSEvents {
+export interface IECSEvents {
     /**
      * 追加事件到队列
      *

--- a/lib/ECSSystem.ts
+++ b/lib/ECSSystem.ts
@@ -2,12 +2,12 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSEnvironment } from "./ECSEnvironment";
+import { IECSEnvironment } from "./ECSEnvironment";
 
 /**
  * 系统接口
  */
-export abstract class ECSSystem {
+export abstract class IECSSystem {
     /**
      * 返回类名
      */
@@ -28,7 +28,7 @@ export abstract class ECSSystem {
     /**
      * 系统所在的 ECS 环境
      */
-    get ecs(): ECSEnvironment {
+    get ecs(): IECSEnvironment {
         if (!this._ecs) {
             throw new TypeError("[ECS] System.ecs is undefined");
         }
@@ -38,7 +38,7 @@ export abstract class ECSSystem {
     /**
      * 设置系统所属 ECS 环境
      */
-    setECSEnvironment(env: ECSEnvironment | undefined) {
+    setECSEnvironment(env: IECSEnvironment | undefined) {
         this._ecs = env;
     }
 
@@ -74,5 +74,5 @@ export abstract class ECSSystem {
     /**
      * 系统所属的 ECS，由 ECS 设置
      */
-    private _ecs: ECSEnvironment | undefined = undefined;
+    private _ecs: IECSEnvironment | undefined = undefined;
 }

--- a/lib/ECSSystems.ts
+++ b/lib/ECSSystems.ts
@@ -2,19 +2,19 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSSystem } from "./ECSSystem";
+import { IECSSystem } from "./ECSSystem";
 import { Constructor } from "./__private";
 
 /**
  * 系统集合
  */
-export interface ECSSystems {
+export interface IECSSystems {
     /**
      * 返回指定名字的系统
      *
      * @param constructor
      */
-    get<T extends ECSSystem>(constructor: Constructor<T>): T;
+    get<T extends IECSSystem>(constructor: Constructor<T>): T;
 
     /**
      * 添加系统
@@ -22,22 +22,22 @@ export interface ECSSystems {
      * @param system
      * @param priority
      */
-    add(system: ECSSystem, priority?: number): ECSSystems;
+    add<T extends IECSSystem>(system: T, priority?: number): IECSSystems;
 
     /**
      * 移除系统
      *
      * @param system
      */
-    delete(system: ECSSystem): ECSSystems;
+    delete<T extends IECSSystem>(system: T): IECSSystems;
 
     /**
      * 移除所有系统
      */
-    clear(): ECSSystems;
+    clear(): IECSSystems;
 
     /**
      * 按照优先级对所有系统排序，数值小的优先执行
      */
-    sort(): ECSSystems;
+    sort(): IECSSystems;
 }

--- a/lib/impl/ECSComponentsImpl.ts
+++ b/lib/impl/ECSComponentsImpl.ts
@@ -2,7 +2,7 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSComponentInterface } from "../ECSComponent";
+import { IECSComponentInterface } from "../ECSComponent";
 import { IECSComponents } from "../ECSComponents";
 import { Constructor } from "../__private";
 
@@ -14,7 +14,7 @@ export class ECSComponentsImpl implements IECSComponents {
         return this._all.size;
     }
 
-    all<T extends ECSComponentInterface>(
+    all<T extends IECSComponentInterface>(
         constructor: Constructor<T>
     ): Array<T> {
         const name = constructor.name;
@@ -24,7 +24,7 @@ export class ECSComponentsImpl implements IECSComponents {
         );
     }
 
-    get<T extends ECSComponentInterface>(constructor: Constructor<T>): T {
+    get<T extends IECSComponentInterface>(constructor: Constructor<T>): T {
         const components = this.all<T>(constructor);
         if (components.length === 0) {
             throw new RangeError(
@@ -34,7 +34,7 @@ export class ECSComponentsImpl implements IECSComponents {
         return components[0];
     }
 
-    add(component: ECSComponentInterface): void {
+    add(component: IECSComponentInterface): void {
         const name = component.name;
         if (typeof name !== "string" || name.length === 0) {
             throw new RangeError(
@@ -44,13 +44,13 @@ export class ECSComponentsImpl implements IECSComponents {
 
         let components = this._all.get(name);
         if (!components) {
-            components = new Array<ECSComponentInterface>();
+            components = new Array<IECSComponentInterface>();
             this._all.set(name, components);
         }
         components.push(component);
     }
 
-    delete(component: ECSComponentInterface): void {
+    delete(component: IECSComponentInterface): void {
         const components = this._all.get(component.name);
         if (components) {
             const i = components.indexOf(component);
@@ -63,7 +63,7 @@ export class ECSComponentsImpl implements IECSComponents {
     /**
      * 按照类型分组的所有组件
      */
-    private readonly _all = new Map<string, Array<ECSComponentInterface>>();
+    private readonly _all = new Map<string, Array<IECSComponentInterface>>();
 }
 
 //// private
@@ -71,4 +71,4 @@ export class ECSComponentsImpl implements IECSComponents {
 /**
  * 预定义的空组件集合
  */
-const emptyComponentsSet = new Array<ECSComponentInterface>();
+const emptyComponentsSet = new Array<IECSComponentInterface>();

--- a/lib/impl/ECSComponentsImpl.ts
+++ b/lib/impl/ECSComponentsImpl.ts
@@ -3,13 +3,13 @@
  */
 
 import { ECSComponentInterface } from "../ECSComponent";
-import { ECSComponents } from "../ECSComponents";
+import { IECSComponents } from "../ECSComponents";
 import { Constructor } from "../__private";
 
 /**
  * 组件集合的实现
  */
-export class ECSComponentsImpl implements ECSComponents {
+export class ECSComponentsImpl implements IECSComponents {
     size(): number {
         return this._all.size;
     }

--- a/lib/impl/ECSEntitiesImpl.ts
+++ b/lib/impl/ECSEntitiesImpl.ts
@@ -2,14 +2,14 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSEntities } from "../ECSEntities";
+import { IECSEntities } from "../ECSEntities";
 import { ECSEntity } from "../ECSEntity";
 import { ECSComponentsImpl } from "./ECSComponentsImpl";
 
 /**
  * 实体集合的实现
  */
-export class ECSEntitiesImpl implements ECSEntities {
+export class ECSEntitiesImpl implements IECSEntities {
     /**
      * 跟踪所有组件
      */

--- a/lib/impl/ECSEventsImpl.ts
+++ b/lib/impl/ECSEventsImpl.ts
@@ -3,14 +3,14 @@
  */
 
 import { ECSEvent } from "../ECSEvent";
-import { ECSEvents } from "../ECSEvents";
+import { IECSEvents } from "../ECSEvents";
 import { Constructor } from "../__private";
 
 /**
  * 事件集合的实现
  */
-export class ECSEventsImpl implements ECSEvents {
-    push(event: ECSEvent): void {
+export class ECSEventsImpl<T extends ECSEvent> implements IECSEvents {
+    push(event: T): void {
         const name = event.name;
         if (typeof name !== "string" || name.length === 0) {
             throw new RangeError(
@@ -20,7 +20,7 @@ export class ECSEventsImpl implements ECSEvents {
 
         let list = this._events.get(name);
         if (!list) {
-            list = new Array<ECSEvent>();
+            list = new Array<T>();
             this._events.set(name, list);
         }
         if (event.unique) {
@@ -29,14 +29,15 @@ export class ECSEventsImpl implements ECSEvents {
         list.push(event);
     }
 
-    fetch<T extends ECSEvent>(constructor: Constructor<T>): T[] {
+    fetch<T>(constructor: Constructor<T>): T[] {
         const name = constructor.name;
         return (
-            (this._events.get(name) as Array<T>) ?? (emptyEventList as Array<T>)
+            // TODO: 令人疑惑
+            (this._events.get(name) as unknown as Array<T>) ?? (emptyEventList as unknown as Array<T>)
         );
     }
 
-    has<T extends ECSEvent>(constructor: Constructor<T>): boolean {
+    has<T>(constructor: Constructor<T>): boolean {
         const events = this._events.get(constructor.name);
         return events ? events.length > 0 : false;
     }
@@ -47,7 +48,7 @@ export class ECSEventsImpl implements ECSEvents {
 
     //// private
 
-    private _events = new Map<string, Array<ECSEvent>>();
+    private _events = new Map<string, Array<T>>();
 }
 
 /// private

--- a/lib/impl/ECSImpl.ts
+++ b/lib/impl/ECSImpl.ts
@@ -2,11 +2,11 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSComponents } from "../ECSComponents";
-import { ECSEntities } from "../ECSEntities";
-import { ECSEnvironment } from "../ECSEnvironment";
+import { IECSComponents } from "../ECSComponents";
+import { IECSEntities } from "../ECSEntities";
+import { IECSEnvironment } from "../ECSEnvironment";
 import { ECSEvents } from "../ECSEvents";
-import { ECSSystems } from "../ECSSystems";
+import { IECSSystems } from "../ECSSystems";
 import { ECSEntitiesImpl } from "./ECSEntitiesImpl";
 import { ECSEventsImpl } from "./ECSEventsImpl";
 import { ECSSystemsImpl } from "./ECSSystemsImpl";
@@ -14,11 +14,11 @@ import { ECSSystemsImpl } from "./ECSSystemsImpl";
 /**
  * ECS 实现
  */
-export class ECSImpl implements ECSEnvironment {
+export class ECSImpl implements IECSEnvironment {
     readonly events: ECSEvents;
-    readonly systems: ECSSystems;
-    readonly entities: ECSEntities;
-    readonly components: ECSComponents;
+    readonly systems: IECSSystems;
+    readonly entities: IECSEntities;
+    readonly components: IECSComponents;
 
     private readonly eventsImpl: ECSEventsImpl;
     private readonly systemsImpl: ECSSystemsImpl;

--- a/lib/impl/ECSImpl.ts
+++ b/lib/impl/ECSImpl.ts
@@ -2,10 +2,11 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
+import { ECSEvent } from "../..";
 import { IECSComponents } from "../ECSComponents";
 import { IECSEntities } from "../ECSEntities";
 import { IECSEnvironment } from "../ECSEnvironment";
-import { ECSEvents } from "../ECSEvents";
+import { IECSEvents } from "../ECSEvents";
 import { IECSSystems } from "../ECSSystems";
 import { ECSEntitiesImpl } from "./ECSEntitiesImpl";
 import { ECSEventsImpl } from "./ECSEventsImpl";
@@ -15,12 +16,12 @@ import { ECSSystemsImpl } from "./ECSSystemsImpl";
  * ECS 实现
  */
 export class ECSImpl implements IECSEnvironment {
-    readonly events: ECSEvents;
+    readonly events: IECSEvents;
     readonly systems: IECSSystems;
     readonly entities: IECSEntities;
     readonly components: IECSComponents;
 
-    private readonly eventsImpl: ECSEventsImpl;
+    private readonly eventsImpl: ECSEventsImpl<ECSEvent>;
     private readonly systemsImpl: ECSSystemsImpl;
     private readonly entitiesImpl: ECSEntitiesImpl;
 

--- a/lib/impl/ECSSystemsImpl.ts
+++ b/lib/impl/ECSSystemsImpl.ts
@@ -2,29 +2,29 @@
  * COPYRIGHT 2021 ALL RESERVED. (C) liaoyulei, https://github.com/dualface
  */
 
-import { ECSSystem } from "../ECSSystem";
-import { ECSSystems } from "../ECSSystems";
+import { IECSSystem } from "../ECSSystem";
+import { IECSSystems } from "../ECSSystems";
 import { Constructor } from "../__private";
 import { ECSImpl } from "./ECSImpl";
 
 /**
  * ECS 系统集合的实现
  */
-export class ECSSystemsImpl implements ECSSystems {
+export class ECSSystemsImpl implements IECSSystems {
     /**
      * 所有已经载入完成的系统，按照优先级排序
      */
-    private readonly loaded = new Array<ECSSystem>();
+    private readonly loaded = new Array<IECSSystem>();
 
     /**
      * 按照名字查找所有已经载入完成的系统
      */
-    private readonly loadedByName = new Map<string, ECSSystem>();
+    private readonly loadedByName = new Map<string, IECSSystem>();
 
     /**
      * 保存正在载入中的系统，当 ECSSystem.load() 方法完成后移动到 loaded 队列
      */
-    private readonly loading = new Map<string, [ECSSystem, boolean]>();
+    private readonly loading = new Map<string, [IECSSystem, boolean]>();
 
     /**
      * 系统的运行状态
@@ -82,7 +82,7 @@ export class ECSSystemsImpl implements ECSSystems {
         }
     }
 
-    get<T extends ECSSystem>(constructor: Constructor<T>): T {
+    get<T extends IECSSystem>(constructor: Constructor<T>): T {
         const name = constructor.name;
         const system = this.loadedByName.get(name);
         if (!system) {
@@ -91,7 +91,7 @@ export class ECSSystemsImpl implements ECSSystems {
         return system as T;
     }
 
-    add(system: ECSSystem, priority?: number): ECSSystems {
+    add(system: IECSSystem, priority?: number): IECSSystems {
         const name = system.name;
         if (typeof name !== "string" || name.length === 0) {
             throw new RangeError(
@@ -135,7 +135,7 @@ export class ECSSystemsImpl implements ECSSystems {
         return this;
     }
 
-    delete(system: ECSSystem): ECSSystems {
+    delete(system: IECSSystem): IECSSystems {
         const name = system.name;
         if (this.loadedByName.has(name)) {
             // 从载入完成的列表中删除指定 system
@@ -169,14 +169,14 @@ export class ECSSystemsImpl implements ECSSystems {
         return this;
     }
 
-    clear(): ECSSystems {
+    clear(): IECSSystems {
         this.loadedByName.forEach((system) => this.delete(system));
         this.loading.forEach((pair) => this.delete(pair[0]));
         return this;
     }
 
-    sort(): ECSSystems {
-        this.loaded.sort((a: ECSSystem, b: ECSSystem): number => {
+    sort(): IECSSystems {
+        this.loaded.sort((a: IECSSystem, b: IECSSystem): number => {
             if (a.priority > b.priority) {
                 return 1;
             } else if (a.priority < b.priority) {


### PR DESCRIPTION
1. 接口命名不大众约定，前面加 ”I“；造成阅读代码时候难以抽象理解；
2. 有些接口的职责没有明确，所以泛型运用的有些奇怪；
3. 先规范一些使用，后期再抽象框架；期待；